### PR TITLE
Add simple podium summary

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -79,7 +79,11 @@ def main():
     constructor_points = _constructor_points_for_year(years[-1])
     result = predict_race(model, sector_times, drivers, constructor_points)
 
+    podium = result.head(3)
     print(result)
+    print("\nPodium:")
+    for pos, driver in enumerate(podium["Driver"], start=1):
+        print(f"P{pos}: {driver}")
     print(
         f"Model Error on years {','.join(map(str, years))} (MAE): {mae:.2f} seconds"
     )


### PR DESCRIPTION
## Summary
- show top 3 drivers after calling `predict_race`
- print podium positions before reporting MAE

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683b158bff248331b1e21df23a6d39a0