### PR TITLE
Update train years default

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ running predictions or using the web form.
 3. Run the prediction script specifying the race key **or the round number** 🔢. Use
    `--train-years` to provide a comma separated list of seasons used for training:
 ```bash
-python3 predict.py chinese_gp --train-years 2022,2023,2024
+python3 predict.py chinese_gp --train-years 2021,2022,2023,2024
 # or simply
 python3 predict.py --round 5 --year 2025
 ```

--- a/predict.py
+++ b/predict.py
@@ -28,8 +28,8 @@ def main():
     parser.add_argument("--year", type=int, default=2025, help="Season year for --round")
     parser.add_argument(
         "--train-years",
-        default="2024",
-        help="Comma separated list of years to train on (default 2024)",
+        default="2021,2022,2023,2024",
+        help="Comma separated list of years to train on (default 2021,2022,2023,2024)",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- broaden default training years to include 2021-2024
- adjust example command in README for new default

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_683b1586da9c83318976a64038e04711