### PR TITLE
Add configurable caching for FastF1 scripts

### DIFF
--- a/calc_overtake_potential.py
+++ b/calc_overtake_potential.py
@@ -1,6 +1,8 @@
 import argparse
 import fastf1
+import os
 import pandas as pd
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 
 
 def _track_overtake_potential(session_r) -> float:

--- a/dump_ff1_times.py
+++ b/dump_ff1_times.py
@@ -3,12 +3,12 @@ import os
 import pandas as pd
 import argparse
 import fastf1
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 from predictor.openf1_utils import slugify
 
 
 def dump_session_times(year: int, grand_prix: str, outdir: str = "ff1_cache_dump") -> str:
     """Export fastest lap times from FastF1 cache to CSV."""
-    fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
     ff1_map = [
         ("FP1", "FP1Time_s"),
         ("FP2", "FP2Time_s"),

--- a/prediction1.py
+++ b/prediction1.py
@@ -1,4 +1,5 @@
 import fastf1
+import os
 import pandas as pd
 import numpy as np
 from sklearn.model_selection import train_test_split
@@ -6,7 +7,7 @@ from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.metrics import mean_absolute_error
 
 # Enable FastF1 caching
-fastf1.Cache.enable_cache("f1_cache")
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 
 # Load FastF1 2024 Australian GP race session
 session_2024 = fastf1.get_session(2024, 3, "R")

--- a/prediction2.py
+++ b/prediction2.py
@@ -1,4 +1,5 @@
 import fastf1
+import os
 import pandas as pd
 import numpy as np
 from sklearn.model_selection import train_test_split
@@ -6,7 +7,7 @@ from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.metrics import mean_absolute_error
 
 # Enable FastF1 caching
-fastf1.Cache.enable_cache("f1_cache")
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 
 # Load 2024 Chinese GP race session
 session_2024 = fastf1.get_session(2024, "China", "R")

--- a/prediction2_nochange.py
+++ b/prediction2_nochange.py
@@ -1,4 +1,5 @@
 import fastf1
+import os
 import pandas as pd
 import numpy as np
 from sklearn.model_selection import train_test_split
@@ -6,7 +7,7 @@ from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.metrics import mean_absolute_error
 
 # Enable FastF1 caching
-fastf1.Cache.enable_cache("f1_cache")
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 
 # Load FastF1 2024 Australian GP race session
 session_2024 = fastf1.get_session(2024, "China", "R")

--- a/prediction2_olddrivers.py
+++ b/prediction2_olddrivers.py
@@ -1,4 +1,5 @@
 import fastf1
+import os
 import pandas as pd
 import numpy as np
 from sklearn.model_selection import train_test_split
@@ -6,7 +7,7 @@ from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.metrics import mean_absolute_error
 
 # Enable FastF1 caching
-fastf1.Cache.enable_cache("f1_cache")
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 
 # Load 2024 Chinese GP race session
 session_2024 = fastf1.get_session(2024, "China", "R")

--- a/prediction3.py
+++ b/prediction3.py
@@ -1,4 +1,5 @@
 import fastf1
+import os
 import pandas as pd
 import numpy as np
 import requests
@@ -7,7 +8,7 @@ from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.metrics import mean_absolute_error
 
 # Enable FastF1 caching
-fastf1.Cache.enable_cache("f1_cache")
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 
 # Load 2024 Japanese GP race session, lap and sector times
 session_2024 = fastf1.get_session(2024, "Japan", "R")

--- a/prediction4.py
+++ b/prediction4.py
@@ -1,4 +1,5 @@
 import fastf1
+import os
 import pandas as pd
 import numpy as np
 import requests
@@ -7,7 +8,7 @@ from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.metrics import mean_absolute_error
 import matplotlib.pyplot as plt
 
-fastf1.Cache.enable_cache("f1_cache")
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 
 # load 2024 Bahrain race, lap time, sector times
 session_2024 = fastf1.get_session(2024, "Bahrain", "R")

--- a/prediction5.py
+++ b/prediction5.py
@@ -1,4 +1,5 @@
 import fastf1
+import os
 import pandas as pd
 import numpy as np
 import requests
@@ -8,7 +9,7 @@ from sklearn.metrics import mean_absolute_error
 import matplotlib.pyplot as plt
 
 
-fastf1.Cache.enable_cache("f1_cache")
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 
 # Load 2024 Jeddah session
 session_2024 = fastf1.get_session(2024, "Saudi Arabia", "R")

--- a/prediction6.py
+++ b/prediction6.py
@@ -1,4 +1,5 @@
 import fastf1
+import os
 import pandas as pd
 import numpy as np
 import requests
@@ -8,7 +9,7 @@ from sklearn.metrics import mean_absolute_error
 import matplotlib.pyplot as plt
 from sklearn.impute import SimpleImputer
 
-fastf1.Cache.enable_cache("f1_cache")
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 
 # load the 2024 miami session data
 session_2024 = fastf1.get_session(2024, "Miami", "R")

--- a/prediction7.py
+++ b/prediction7.py
@@ -1,4 +1,5 @@
 import fastf1
+import os
 import pandas as pd
 import numpy as np
 import requests
@@ -8,7 +9,7 @@ from sklearn.metrics import mean_absolute_error
 import matplotlib.pyplot as plt
 from sklearn.impute import SimpleImputer
 
-fastf1.Cache.enable_cache("f1_cache")
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 
 # load the 2024 Emilia Romagna session data
 session_2024 = fastf1.get_session(2024, 7, "Q")

--- a/prediction8.py
+++ b/prediction8.py
@@ -1,4 +1,5 @@
 import fastf1
+import os
 import pandas as pd
 import numpy as np
 import requests
@@ -8,7 +9,7 @@ from sklearn.metrics import mean_absolute_error
 import matplotlib.pyplot as plt
 from sklearn.impute import SimpleImputer
 
-fastf1.Cache.enable_cache("f1_cache")
+fastf1.Cache.enable_cache(os.environ.get("FASTF1_CACHE_DIR", "f1_cache"))
 
 # load the 2024 Monaco session data
 session_2024 = fastf1.get_session(2024, 8, "R")


### PR DESCRIPTION
## Summary
- set FastF1 cache directory via `FASTF1_CACHE_DIR` environment variable
- update prediction examples and utilities to import `os`
- initialize cache after imports in scripts

## Testing
- `python -m py_compile prediction1.py prediction2.py prediction2_nochange.py prediction2_olddrivers.py prediction3.py prediction4.py prediction5.py prediction6.py prediction7.py prediction8.py calc_overtake_potential.py dump_ff1_times.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b15838bd4833193aed00037ac557f